### PR TITLE
New LocalizerDiagnosticMode and fixed MissingTranslation

### DIFF
--- a/AspNetCore.Localizer.Json.Shared/JsonOptions/JsonLocalizationOptions.cs
+++ b/AspNetCore.Localizer.Json.Shared/JsonOptions/JsonLocalizationOptions.cs
@@ -135,6 +135,11 @@ namespace AspNetCore.Localizer.Json.JsonOptions
         public string MissingTranslationsOutputFile { get; set; } = DEFAULT_MISSING_TRANSLATIONS;
 
         /// <summary>
+        /// If set to true, the localizer will replace all the translated text with "*" to help identify missing translations.
+        /// </summary>
+        public bool LocalizerDiagnosticMode { get; set; } = false;
+
+        /// <summary>
         /// If a list of files is provided, the localizer will not attempt to scan i18n directories. This option is required for Blazor Wasm.
         /// </summary>
         public string[] JsonFileList { get; set; } = null;

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ services.AddJsonLocalization(options => {
 - **PluralSeparator** : *_default value: |*. Seperator used to get singular or pluralized version of localization. More information in *Pluralization*
 - **MissingTranslationLogBehavior** : *_default value: LogConsoleError*. Define the logging mode
 - **LocalizationMode** : *_default value: Basic*. Define the localization mode for the Json file. Currently Basic and I18n. More information in *LocalizationMode*
-- **MissingTranslationsOutputFile** : This enables to specify in which file the missing translations will be written when `MissingTranslationLogBehavior = MissingTranslationLogBehavior.CollectToJSON`, defaults to `MissingTranslations.json`
+- **MissingTranslationsOutputFile** : This enables to specify in which file the missing translations will be written when `MissingTranslationLogBehavior = MissingTranslationLogBehavior.CollectToJSON`, defaults to `MissingTranslations-<locale>.json`
 - **IgnoreJsonErrors**: This properly will ignore the JSON errors if set to true. Recommended in production but not in development.
-
+- **LocalizerDiagnosticMode**: When set to true, the localizer will replace all localized with "X". This is designed to identify text that is _not using the localizer_ on the page.
 
 ### Search patterns when UseBaseName = true
 

--- a/test/AspNetCore.Localizer.Json.Sample.I18nTest/MissingTranslations.json
+++ b/test/AspNetCore.Localizer.Json.Sample.I18nTest/MissingTranslations.json
@@ -1,1 +1,0 @@
-{"default":{"MissingText1":"MissingText1","MissingText2":"MissingText2"}}

--- a/test/AspNetCore.Localizer.Json.Sample.I18nTest/Startup.cs
+++ b/test/AspNetCore.Localizer.Json.Sample.I18nTest/Startup.cs
@@ -56,6 +56,7 @@ namespace AspNetCore.Localizer.Json.Sample.I18nTest
                 options.IsAbsolutePath = _jsonLocalizationOptions.IsAbsolutePath;
                 options.MissingTranslationLogBehavior = MissingTranslationLogBehavior.CollectToJSON;
                 options.LocalizationMode = LocalizationMode.I18n;
+                options.LocalizerDiagnosticMode = _jsonLocalizationOptions.LocalizerDiagnosticMode;
             });
             
             services.Configure<RequestLocalizationOptions>(options =>

--- a/test/AspNetCore.Localizer.Json.Sample.I18nTest/appsettings.json
+++ b/test/AspNetCore.Localizer.Json.Sample.I18nTest/appsettings.json
@@ -16,6 +16,7 @@
     "SupportedCultureInfos": [ "en-US", "fr-FR", "pt-PT" ],
     "IsAbsolutePath": true,
     "FileEncodingName": "utf-8",
-    "UseBaseName": false
+    "UseBaseName": false,
+    "LocalizerDiagnosticMode": false
   }
 }

--- a/test/AspNetCore.Localizer.Json.Test/Localizer/DiagnosticTranslationTests.cs
+++ b/test/AspNetCore.Localizer.Json.Test/Localizer/DiagnosticTranslationTests.cs
@@ -1,0 +1,41 @@
+﻿using AspNetCore.Localizer.Json.Localizer;
+using AspNetCore.Localizer.Json.Test.Helpers;
+using Microsoft.Extensions.Localization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections;
+using System.Globalization;
+using System.Linq;
+using AspNetCore.Localizer.Json.JsonOptions;
+using LocalizedString = Microsoft.Extensions.Localization.LocalizedString;
+using System.IO;
+
+namespace AspNetCore.Localizer.Json.Test.Localizer
+{
+    [TestClass]
+    public class DiagnosticTranslationTests
+    {
+        [TestInitialize]
+        public void Init()
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+        }
+
+        [TestMethod]
+        public void Should_Blank_Name()
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
+
+            // Arrange           
+            JsonStringLocalizer localizer = JsonStringLocalizerHelperFactory.Create(new JsonLocalizationOptions()
+            {
+                DefaultCulture = new CultureInfo("fr-FR"),
+                LocalizerDiagnosticMode = true
+            });
+
+            LocalizedString result = localizer.GetString("BaseName1");
+
+            Assert.AreEqual("XXXXXXXXX", result);
+        }
+    }
+}

--- a/test/AspNetCore.Localizer.Json.Test/Localizer/MissingTranslationsTest.cs
+++ b/test/AspNetCore.Localizer.Json.Test/Localizer/MissingTranslationsTest.cs
@@ -40,12 +40,20 @@ namespace AspNetCore.Localizer.Json.Test.Localizer
         public void Should_Track_Colored_NotFound()
         {
             var defaultJsonFile = JsonLocalizationOptions.DEFAULT_MISSING_TRANSLATIONS;
-            if (File.Exists(defaultJsonFile))
-                File.Delete(defaultJsonFile);
+            //add 'default' before extension in filename
+            var extension = Path.GetExtension(defaultJsonFile);
+            var name = Path.GetFileNameWithoutExtension(defaultJsonFile);
+            var actualName = $"{name}-default{extension}";
+            
+            if (File.Exists(actualName))
+                File.Delete(actualName);
             InitLocalizer("en-AU");
             var result = localizer.GetString("Colored",false);
             Assert.IsTrue(result.ResourceNotFound);
-            Assert.IsTrue(File.Exists(defaultJsonFile));
+            // list all files that have .json extension
+            var allJsonFiles = Directory.GetFiles($".", "*.json").ToList();
+
+            Assert.IsTrue(allJsonFiles.Exists(s => s.Contains(name)));
         }
 
         /// <summary>


### PR DESCRIPTION
- The `JsonStringLocalizer` class has been updated to use the `LocalizerDiagnosticMode` property. If `LocalizerDiagnosticMode` is true, the `JsonStringLocalizer` will return a `LocalizedString` where the value is a string of repeated 'X' characters.
- The `JsonStringLocalizer` class has been updated to write missing translations to a file for each locale. Previously, all missing translations were written to a single file.
- The `MissingTranslationsTest` class has been updated to check for a file for each locale when testing if missing translations are tracked.
- A new test class `DiagnosticTranslationTests` has been added to test the new `LocalizerDiagnosticMode` functionality.