### PR TITLE
Add option to load localization from file system

### DIFF
--- a/AspNetCore.Localizer.Json.Shared/JsonOptions/JsonLocalizationOptions.cs
+++ b/AspNetCore.Localizer.Json.Shared/JsonOptions/JsonLocalizationOptions.cs
@@ -141,5 +141,12 @@ namespace AspNetCore.Localizer.Json.JsonOptions
         /// Additional paths to search for JSON files.
         /// </summary>
         public string[] AdditionalResourcesPaths { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// Determines whether localization files should be loaded from embedded resources.
+        /// Defaults to <c>true</c> to keep the previous behaviour.
+        /// When set to <c>false</c>, files are loaded directly from the file system.
+        /// </summary>
+        public bool UseEmbeddedResources { get; set; } = true;
     }
 }

--- a/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationBasicModeGenerator.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationBasicModeGenerator.cs
@@ -22,8 +22,10 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
             {
                 try
                 {
-                    var tempLocalization = ReadAndDeserializeEmbeddedResource<string, JsonLocalizationFormat>(
-                        resourceName, options.FileEncoding);
+                    Dictionary<string, JsonLocalizationFormat>? tempLocalization =
+                        options.UseEmbeddedResources
+                            ? ReadAndDeserializeEmbeddedResource<string, JsonLocalizationFormat>(resourceName, options.FileEncoding)
+                            : ReadAndDeserializeFile<string, JsonLocalizationFormat>(resourceName, options.FileEncoding);
 
                     if (tempLocalization == null)
                         continue;
@@ -107,6 +109,12 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
 
             using var reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: false);
             var json = reader.ReadToEnd();
+            return System.Text.Json.JsonSerializer.Deserialize<Dictionary<TKey, TValue>>(json);
+        }
+
+        private static Dictionary<TKey, TValue>? ReadAndDeserializeFile<TKey, TValue>(string filePath, Encoding encoding)
+        {
+            var json = File.ReadAllText(filePath, encoding);
             return System.Text.Json.JsonSerializer.Deserialize<Dictionary<TKey, TValue>>(json);
         }
     }

--- a/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationI18NModeGenerator.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationI18NModeGenerator.cs
@@ -79,12 +79,10 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
         {
             try
             {
-                var assembly = options.AssemblyHelper.GetAssembly();
-                using Stream? stream = assembly.GetManifestResourceStream(resourceName);
-                if (stream == null)
-                {
-                    throw new FileNotFoundException($"La ressource incorporée '{resourceName}' est introuvable.");
-                }
+                using Stream stream = options.UseEmbeddedResources
+                    ? options.AssemblyHelper.GetAssembly().GetManifestResourceStream(resourceName)
+                    ?? throw new FileNotFoundException($"La ressource incorporée '{resourceName}' est introuvable.")
+                    : File.OpenRead(resourceName);
 
                 if (stream.CanSeek)
                 {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ services.AddJsonLocalization(options => {
 - **ResourcesPath** : _Default value : `$"{_env.WebRootPath}/Resources/"`_. Base path of your resources. The plugin will
   browse the folder and sub-folders and load all present JSON files.
 - **AdditionalResourcesPaths** : _Default value : null_. Optionnal array of additional paths to search for resources.
+- **UseEmbeddedResources** : _default value: true_. When set to `false`, JSON files are loaded directly from the file system instead of from embedded resources.
 - **CacheDuration** : _Default value : 30 minutes_. We cache all values to memory to avoid loading files for each
   request, this parameter defines the time after which the cache is refreshed.
 - **FileEncoding** : _default value : UTF8_. Specify the file encoding.

--- a/test/AspNetCore.Localizer.Json.Test/AspNetCore.Localizer.Json.Test.csproj
+++ b/test/AspNetCore.Localizer.Json.Test/AspNetCore.Localizer.Json.Test.csproj
@@ -35,5 +35,8 @@
     <EmbeddedResource Include="fallback\**\*.json" WithCulture="false" />
     <EmbeddedResource Include="encoding\**\*.json" WithCulture="false" />
     <EmbeddedResource Include="interpolation\**\*.json" WithCulture="false" />
+    <Content Include="physical\**\*.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/test/AspNetCore.Localizer.Json.Test/Localizer/PhysicalFileLocalizationTest.cs
+++ b/test/AspNetCore.Localizer.Json.Test/Localizer/PhysicalFileLocalizationTest.cs
@@ -1,0 +1,31 @@
+using AspNetCore.Localizer.Json.Localizer;
+using AspNetCore.Localizer.Json.Test.Helpers;
+using Microsoft.Extensions.Localization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
+using System.Reflection;
+using AspNetCore.Localizer.Json.JsonOptions;
+
+namespace AspNetCore.Localizer.Json.Test.Localizer
+{
+    [TestClass]
+    public class PhysicalFileLocalizationTest
+    {
+        [TestMethod]
+        public void Should_Read_From_Physical_File()
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+
+            JsonStringLocalizer localizer = JsonStringLocalizerHelperFactory.Create(new JsonLocalizationOptions()
+            {
+                DefaultCulture = new CultureInfo("en-US"),
+                SupportedCultureInfos = [ new CultureInfo("en-US") ],
+                ResourcesPath = "physical",
+                UseEmbeddedResources = false
+            });
+
+            LocalizedString result = localizer.GetString("BaseName1");
+            Assert.AreEqual("My Base Name 1", result.Value);
+        }
+    }
+}

--- a/test/AspNetCore.Localizer.Json.Test/physical/localization.json
+++ b/test/AspNetCore.Localizer.Json.Test/physical/localization.json
@@ -1,0 +1,25 @@
+﻿{
+    "BaseName1": {
+        "Values": {
+            "en-US": "My Base Name 1",
+            "fr-FR": "Mon Nom de Base 1"
+        }
+    },
+    "BaseName2": {
+        "Values": {
+            "en-US": "My Base Name 2",
+            "fr-FR": "Mon Nom de Base 2"
+        }
+    },
+    "NoFrench": {
+        "Values": {
+            "en-US": "No more french"
+        }
+    },
+    "CaseInsensitiveCultureName": {
+        "Values": {
+            "en-us": "US English",
+            "FR-FR": "French"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `UseEmbeddedResources` option to load JSON translations from disk
- support file system paths in `JsonStringLocalizerBase`
- update localization mode generators for disk access
- document new option in README
- test reading localization from physical files