### PR TITLE
fix: P0 thread-safety - _lazyLocalization, _cachedPluralizationRules, _missingTranslations, LocalizationModeBase

### DIFF
--- a/AspNetCore.Localizer.Json.Shared/Localizer/JsonStringLocalizer.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/JsonStringLocalizer.cs
@@ -3,6 +3,7 @@ using AspNetCore.Localizer.Json.Extensions;
 using AspNetCore.Localizer.Json.Format;
 using Microsoft.Extensions.Localization;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -17,7 +18,7 @@ namespace AspNetCore.Localizer.Json.Localizer
     internal partial class JsonStringLocalizer : JsonStringLocalizerBase, IJsonStringLocalizer
     {
         private readonly string? _missingTranslationsFile = null;
-        private readonly Dictionary<string, Dictionary<string, string>> _missingTranslations = new();
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _missingTranslations = new();
         private bool _disposed = false;
 
         public JsonStringLocalizer(IOptions<JsonLocalizationOptions> localizationOptions) : base(localizationOptions)
@@ -105,15 +106,18 @@ namespace AspNetCore.Localizer.Json.Localizer
 
             string nameWithRule = $"{name}.{applicableRule}";
 
-            if (_lazyLocalization.Value.TryGetValue(nameWithRule, out var localizedValue))
+            if (_localizationCache.TryGetValue(_currentCulture, out var dict))
             {
-                return FormatLocalizedString(name, localizedValue.Value, count, arguments);
-            }
+                if (dict.TryGetValue(nameWithRule, out var localizedValue))
+                {
+                    return FormatLocalizedString(name, localizedValue.Value, count, arguments);
+                }
 
-            string nameWithOtherRule = $"{name}.{PluralizationConstants.Other}";
-            if (_lazyLocalization.Value.TryGetValue(nameWithOtherRule, out var localizedOtherValue))
-            {
-                return FormatLocalizedString(name, localizedOtherValue.Value, count, arguments);
+                string nameWithOtherRule = $"{name}.{PluralizationConstants.Other}";
+                if (dict.TryGetValue(nameWithOtherRule, out var localizedOtherValue))
+                {
+                    return FormatLocalizedString(name, localizedOtherValue.Value, count, arguments);
+                }
             }
 
             string fallback = GetString(name, true);
@@ -152,7 +156,12 @@ namespace AspNetCore.Localizer.Json.Localizer
         {
             InitCorrectJsonCulture();
 
-            return _lazyLocalization.Value.Where(w => includeParentCultures || !w.Value.IsParent)
+            if (!_localizationCache.TryGetValue(_currentCulture, out var dict))
+            {
+                return Enumerable.Empty<LocalizedString>();
+            }
+
+            return dict.Where(w => includeParentCultures || !w.Value.IsParent)
                 .Select(l =>
                     new LocalizedString(l.Key, l.Value.Value ?? l.Key, resourceNotFound: l.Value.Value == null))
                 .OrderBy(s => s.Name);
@@ -179,7 +188,7 @@ namespace AspNetCore.Localizer.Json.Localizer
             // Initialize culture BEFORE lookup to ensure culture-aware access
             var culture = InitCorrectJsonCulture(true);
 
-            if (_lazyLocalization.Value.TryGetValue(name, out LocalizatedFormat? localizedValue))
+            if (_localizationCache.TryGetValue(_currentCulture, out var dict) && dict.TryGetValue(name, out LocalizatedFormat? localizedValue))
             {
                 return localizedValue.Value;
             }
@@ -238,26 +247,21 @@ namespace AspNetCore.Localizer.Json.Localizer
         {
             var cultureName = culture?.Name ?? "default";
 
-            if (!_missingTranslations.ContainsKey(cultureName))
-            {
-                _missingTranslations[cultureName] = new Dictionary<string, string>();
-            }
+            var cultureDict = _missingTranslations.GetOrAdd(cultureName, _ => new ConcurrentDictionary<string, string>());
 
-            _missingTranslations[cultureName][name] = name;
+            cultureDict[name] = name;
 
             // Limiter la taille du cache des traductions manquantes
-            if (_missingTranslations[cultureName].Count > LocalizationOptions.Value.MaxMissingTranslations)
+            if (cultureDict.Count > LocalizationOptions.Value.MaxMissingTranslations)
             {
-                var keysToRemove = _missingTranslations[cultureName].Keys
-                    .Take(_missingTranslations[cultureName].Count - LocalizationOptions.Value.MaxMissingTranslations)
+                var keysToRemove = cultureDict.Keys
+                    .Take(cultureDict.Count - LocalizationOptions.Value.MaxMissingTranslations)
                     .ToList();
 
                 foreach (var key in keysToRemove)
                 {
-                    _missingTranslations[cultureName].Remove(key);
+                    cultureDict.TryRemove(key, out _);
                 }
-
-
             }
 
             // Write to file
@@ -269,7 +273,7 @@ namespace AspNetCore.Localizer.Json.Localizer
 
                 try
                 {
-                    var json = JsonSerializer.Serialize(_missingTranslations[cultureName], new JsonSerializerOptions { WriteIndented = true });
+                    var json = JsonSerializer.Serialize(cultureDict.ToDictionary(kvp => kvp.Key, kvp => kvp.Value), new JsonSerializerOptions { WriteIndented = true });
                     File.WriteAllText(fileNameWithCulture, json);
                 }
                 catch (Exception ex)

--- a/AspNetCore.Localizer.Json.Shared/Localizer/JsonStringLocalizerBase.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/JsonStringLocalizerBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -25,9 +26,9 @@ namespace AspNetCore.Localizer.Json.Localizer
         private TimeSpan _memCacheDuration;
 
         private const string CacheKey = "LocalizationBlob";
-        private string _currentCulture = string.Empty;
+        protected string _currentCulture = string.Empty;
         // Lazy-loaded localization dictionary to defer resource loading until first access
-        protected Lazy<Dictionary<string, LocalizatedFormat>> _lazyLocalization;
+        protected ConcurrentDictionary<string, Dictionary<string, LocalizatedFormat>> _localizationCache = new();
 
         private readonly Lazy<Dictionary<string, IPluralizationRuleSet>> _pluralizationRuleSets = new(() => new Dictionary<string, IPluralizationRuleSet>());
 
@@ -56,10 +57,6 @@ namespace AspNetCore.Localizer.Json.Localizer
 
             _memCacheDuration = LocalizationOptions.Value.CacheDuration;
 
-            // Initialiser _lazyLocalization avec un dictionnaire vide
-            _lazyLocalization = new Lazy<Dictionary<string, LocalizatedFormat>>(
-                () => new Dictionary<string, LocalizatedFormat>());
-
             _localizationMode = LocalizationModeFactory.GetLocalisationFromMode(LocalizationOptions.Value.LocalizationMode);
         }
 
@@ -87,37 +84,24 @@ namespace AspNetCore.Localizer.Json.Localizer
             {
                 if (key != null && MemCache.TryGetValue(key, out var cachedLocalization))
                 {
-                    // Réutiliser le Lazy existant au lieu de le recréer
-                    UpdateLazyLocalization(cachedLocalization);
                     SetCurrentCultureToCache(cultureToUse);
+                    UpdateLazyLocalization(cultureToUse.Name, cachedLocalization);
                     return;
                 }
             }
         }
 
-        private readonly Dictionary<string, IPluralizationRuleSet> _cachedPluralizationRules = new();
+        private readonly ConcurrentDictionary<string, IPluralizationRuleSet> _cachedPluralizationRules = new();
         private ILocalizationModeGenerator _localizationMode;
-        private const int MaxCachedPluralizationRules = 10;
 
         protected IPluralizationRuleSet GetPluralizationToUse()
         {
-            if (!_cachedPluralizationRules.TryGetValue(_currentCulture, out var ruleSet))
+            return _cachedPluralizationRules.GetOrAdd(_currentCulture, culture =>
             {
-                ruleSet = _pluralizationRuleSets.Value.TryGetValue(_currentCulture, out var foundRuleSet)
+                return _pluralizationRuleSets.Value.TryGetValue(culture, out var foundRuleSet)
                     ? foundRuleSet
                     : new DefaultPluralizationRuleSet();
-
-                // Limiter la taille du cache LRU
-                if (_cachedPluralizationRules.Count >= MaxCachedPluralizationRules)
-                {
-                    var oldestKey = _cachedPluralizationRules.Keys.First();
-                    _cachedPluralizationRules.Remove(oldestKey);
-                }
-
-                _cachedPluralizationRules[_currentCulture] = ruleSet;
-            }
-
-            return ruleSet;
+            });
         }
         #endregion
 
@@ -133,39 +117,33 @@ namespace AspNetCore.Localizer.Json.Localizer
             if (!MemCache.TryGetValue(GetCacheKey(currentCulture), out var cachedLocalization))
             {
                 ConstructLocalizationObject(currentCulture);
-                MemCache.Set(GetCacheKey(currentCulture), _lazyLocalization.Value, _memCacheDuration);
+                if (_localizationCache.TryGetValue(currentCulture.Name, out var dict))
+                {
+                    MemCache.Set(GetCacheKey(currentCulture), dict, _memCacheDuration);
+                }
                 SetCurrentCultureToCache(currentCulture);
                 return false;
             }
 
-            // Réutiliser le Lazy existant au lieu de le recréer
-            UpdateLazyLocalization(cachedLocalization);
             SetCurrentCultureToCache(currentCulture);
+            UpdateLazyLocalization(currentCulture.Name, cachedLocalization);
             return true;
         }
 
         private void ConstructLocalizationObject(CultureInfo currentCulture)
         {
-            // Localization is now lazy-loaded, so we populate it on first access
             var myFiles = GetJsonFilesPath(currentCulture).ToArray();
             if (myFiles.Length > 0)
             {
                 var newLocalization = _localizationMode.ConstructLocalization(myFiles, currentCulture, LocalizationOptions.Value);
 
-                // Réutiliser le Lazy existant au lieu de le recréer
-                UpdateLazyLocalization(newLocalization);
+                UpdateLazyLocalization(currentCulture.Name, newLocalization);
             }
         }
 
-        /// <summary>
-        /// Crée un nouveau Lazy<Dictionary> pour chaque culture.
-        /// Cela évite la corruption des données lors des changements de culture.
-        /// </summary>
-        private void UpdateLazyLocalization(Dictionary<string, LocalizatedFormat> newLocalization)
+        private void UpdateLazyLocalization(string culture, Dictionary<string, LocalizatedFormat> newLocalization)
         {
-            // Toujours créer un nouveau Lazy pour chaque culture
-            // Cela évite la corruption des données quand on réutilise le même dictionnaire
-            _lazyLocalization = new Lazy<Dictionary<string, LocalizatedFormat>>(() => newLocalization);
+            _localizationCache[culture] = newLocalization;
         }
 
         private IEnumerable<string> GetJsonFilesPath(CultureInfo culture)
@@ -327,10 +305,9 @@ namespace AspNetCore.Localizer.Json.Localizer
                     MemCache?.Dispose();
 
                     // Clear collections
-                    _cachedPluralizationRules?.Clear();
+                    _cachedPluralizationRules.Clear();
 
-                    // Do not clear _lazyLocalization: it may be shared via cache and clearing
-                    // would wipe cached translations for other scopes.
+                    _localizationCache.Clear();
                     if (_pluralizationRuleSets?.IsValueCreated == true)
                     {
                         _pluralizationRuleSets.Value?.Clear();

--- a/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationBasicModeGenerator.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationBasicModeGenerator.cs
@@ -18,8 +18,7 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
         {
             _options = options;
             
-            // Créer un nouveau dictionnaire pour éviter les données résiduelles
-            localization = new Dictionary<string, LocalizatedFormat>();
+            var localization = new Dictionary<string, LocalizatedFormat>();
 
             string parentCultureName = currentCulture.Parent.Name;
             string defaultCultureName = _options.DefaultCulture?.Name;
@@ -39,7 +38,7 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
                     foreach (KeyValuePair<string, JsonLocalizationFormat> temp in tempLocalization)
                     {
                         LocalizatedFormat localizedValue = GetLocalizedValue(currentCulture, parentCultureName, defaultCultureName, temp);
-                        AddOrUpdateLocalizedValue(localizedValue, temp);
+                        AddOrUpdateLocalizedValue(localization, localizedValue, temp);
                     }
                 }
                 catch

--- a/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationI18NModeGenerator.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationI18NModeGenerator.cs
@@ -27,8 +27,7 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
             CultureInfo currentCulture,
             JsonLocalizationOptions options)
         {
-            // Créer un nouveau dictionnaire pour éviter les données résiduelles
-            localization = new Dictionary<string, LocalizatedFormat>();
+            var localization = new Dictionary<string, LocalizatedFormat>();
 
             foreach (string resourceName in resourceNames)
             {
@@ -54,7 +53,7 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
                     }
                 }
 
-                AddValueToLocalization(options, resourceName, isParentForFile);
+                AddValueToLocalization(localization, options, resourceName, isParentForFile);
             }
 
             return localization;
@@ -137,7 +136,7 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
             return string.Empty;
         }
 
-        private void AddValueToLocalization(JsonLocalizationOptions options, string resourceName, bool isParent)
+        private void AddValueToLocalization(Dictionary<string, LocalizatedFormat> localization, JsonLocalizationOptions options, string resourceName, bool isParent)
         {
             try
             {
@@ -160,7 +159,7 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
                 {
                     if (jsonReader.TokenType == JsonTokenType.StartObject)
                     {
-                        TraverseJson(ref jsonReader, string.Empty, isParent);
+                        TraverseJson(localization, ref jsonReader, string.Empty, isParent);
                     }
                 }
             }
@@ -171,7 +170,7 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
             }
         }
 
-        private void TraverseJson(ref Utf8JsonReader jsonReader, string baseKey, bool isParent)
+        private void TraverseJson(Dictionary<string, LocalizatedFormat> localization, ref Utf8JsonReader jsonReader, string baseKey, bool isParent)
         {
             string currentProperty = baseKey;
 
@@ -195,13 +194,14 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
                     case JsonTokenType.String:
                         string value = jsonReader.GetString() ?? string.Empty;
                         AddOrUpdateLocalizedValue(
+                            localization,
                             GetLocalizedValue(new KeyValuePair<string, string>(currentProperty, value), isParent),
                             new KeyValuePair<string, string>(currentProperty, value)
                         );
                         break;
 
                     case JsonTokenType.StartObject:
-                        TraverseJson(ref jsonReader, currentProperty, isParent);
+                        TraverseJson(localization, ref jsonReader, currentProperty, isParent);
                         break;
 
                     case JsonTokenType.EndObject:

--- a/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationModeBase.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationModeBase.cs
@@ -7,32 +7,25 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
 {
     internal abstract class LocalizationModeBase
     {
-        protected Dictionary<string, LocalizatedFormat> localization =
-            new Dictionary<string, LocalizatedFormat>();
-
         protected JsonLocalizationOptions _options;
 
-        protected void AddOrUpdateLocalizedValue<T>(LocalizatedFormat localizedValue, KeyValuePair<string, T> temp)
+        protected static void AddOrUpdateLocalizedValue<T>(Dictionary<string, LocalizatedFormat> localization, LocalizatedFormat localizedValue, KeyValuePair<string, T> temp)
         {
-            // Skip if the localized value is null
             if (localizedValue.Value is null)
             {
                 LocalizatedFormatPool.Return(localizedValue);
                 return;
             }
 
-            // Optimize dictionary access to minimize redundant lookups
             if (localization.TryGetValue(temp.Key, out var existingValue))
             {
                 if (existingValue.IsParent && !localizedValue.IsParent)
                 {
-                    // Return the old value to the pool before replacing
                     LocalizatedFormatPool.Return(existingValue);
                     localization[temp.Key] = localizedValue;
                 }
                 else
                 {
-                    // Return the new value to the pool if not used
                     LocalizatedFormatPool.Return(localizedValue);
                 }
             }

--- a/test/AspNetCore.Localizer.Json.Test/Localizer/ConcurrentAccessTest.cs
+++ b/test/AspNetCore.Localizer.Json.Test/Localizer/ConcurrentAccessTest.cs
@@ -1,0 +1,153 @@
+using AspNetCore.Localizer.Json.Localizer;
+using AspNetCore.Localizer.Json.Test.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using AspNetCore.Localizer.Json.JsonOptions;
+
+namespace AspNetCore.Localizer.Json.Test.Localizer
+{
+    [TestClass]
+    public class ConcurrentAccessTest
+    {
+        [TestMethod]
+        public void Parallel_Culture_Switching_No_Exception()
+        {
+            var cultureFr = new CultureInfo("fr-FR");
+            var cultureEn = new CultureInfo("en-US");
+
+            CultureInfo.CurrentUICulture = cultureEn;
+
+            var localizer = JsonStringLocalizerHelperFactory.Create(new JsonLocalizationOptions
+            {
+                DefaultCulture = cultureEn,
+                SupportedCultureInfos = new()
+                {
+                    cultureEn,
+                    cultureFr
+                },
+                ResourcesPath = "json_files",
+                AssemblyHelper = new AssemblyStub(Assembly.GetExecutingAssembly())
+            });
+
+            var cultures = new[] { cultureEn, cultureFr };
+            var exceptions = new ConcurrentBag<Exception>();
+
+            Parallel.For(0, 100, _ =>
+            {
+                foreach (var culture in cultures)
+                {
+                    CultureInfo.CurrentUICulture = culture;
+
+                    try
+                    {
+                        var val = localizer["Name1"].Value;
+                        var val2 = localizer["Name2"].Value;
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            });
+
+            Assert.IsTrue(exceptions.IsEmpty,
+                $"Concurrent access threw {exceptions.Count} exception(s): {string.Join("; ", exceptions.Select(e => e.GetType().Name + ": " + e.Message).Distinct())}");
+        }
+
+        [TestMethod]
+        public void Parallel_Pluralization_No_Exception()
+        {
+            var cultureFr = new CultureInfo("fr-FR");
+            var cultureEn = new CultureInfo("en-US");
+
+            CultureInfo.CurrentUICulture = cultureEn;
+
+            var localizer = JsonStringLocalizerHelperFactory.Create(new JsonLocalizationOptions
+            {
+                DefaultCulture = cultureEn,
+                SupportedCultureInfos = new()
+                {
+                    cultureEn,
+                    cultureFr
+                },
+                ResourcesPath = "pluralization",
+                AssemblyHelper = new AssemblyStub(Assembly.GetExecutingAssembly())
+            });
+
+            var cultures = new[] { cultureEn, cultureFr };
+            var exceptions = new ConcurrentBag<Exception>();
+
+            Parallel.For(0, 100, _ =>
+            {
+                foreach (var culture in cultures)
+                {
+                    CultureInfo.CurrentUICulture = culture;
+
+                    try
+                    {
+                        var val = localizer.GetPlural("PluralUser", 1).Value;
+                        var val2 = localizer.GetPlural("PluralUser", 2).Value;
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            });
+
+            Assert.IsTrue(exceptions.IsEmpty,
+                $"Concurrent pluralization access threw {exceptions.Count} exception(s): {string.Join("; ", exceptions.Select(e => e.GetType().Name + ": " + e.Message).Distinct())}");
+        }
+
+        [TestMethod]
+        public void Parallel_Mixed_Access_No_Exception()
+        {
+            var cultureFr = new CultureInfo("fr-FR");
+            var cultureEn = new CultureInfo("en-US");
+
+            CultureInfo.CurrentUICulture = cultureEn;
+
+            var localizer = JsonStringLocalizerHelperFactory.Create(new JsonLocalizationOptions
+            {
+                DefaultCulture = cultureEn,
+                SupportedCultureInfos = new()
+                {
+                    cultureEn,
+                    cultureFr
+                },
+                ResourcesPath = "json_files",
+                AssemblyHelper = new AssemblyStub(Assembly.GetExecutingAssembly()),
+                PluralSeparator = '|'
+            });
+
+            var cultures = new[] { cultureEn, cultureFr };
+            var exceptions = new ConcurrentBag<Exception>();
+
+            Parallel.For(0, 100, _ =>
+            {
+                foreach (var culture in cultures)
+                {
+                    CultureInfo.CurrentUICulture = culture;
+
+                    try
+                    {
+                        var val = localizer["Name1"].Value;
+                        var val2 = localizer.GetPlural("Name1", 1).Value;
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            });
+
+            Assert.IsTrue(exceptions.IsEmpty,
+                $"Concurrent mixed access threw {exceptions.Count} exception(s): {string.Join("; ", exceptions.Select(e => e.GetType().Name + ": " + e.Message).Distinct())}");
+        }
+    }
+}


### PR DESCRIPTION
## Problème

Deux champs non thread-safe dans `JsonStringLocalizerBase` (`_lazyLocalization`, `_cachedPluralizationRules`) + `_missingTranslations` dans `JsonStringLocalizer` + champ `localization` partagé dans `LocalizationModeBase`.

### Race 1: `_lazyLocalization`
`UpdateLazyLocalization()` remplaçait le `Lazy<Dictionary>` sans verrou. Thread A lisant `.Value` pendant que Thread B appelle `UpdateLazyLocalization()` pouvait obtenir une référence périmée.

### Race 2: `_cachedPluralizationRules`
`GetPluralizationToUse()` lisait/écrivait un `Dictionary` sans synchronisation. Requêtes concurrentes avec cultures différentes causaient `ArgumentException` (clé déjà ajoutée).

### Race 3: `_missingTranslations`
`WriteMissingTranslations()` ajoutait dans un `Dictionary` sans verrou — source du crash "An item with the same key has already been added".

### Race 4: `LocalizationModeBase.localization`
Champ d'instance partagé entre threads dans `ConstructLocalization`. Deux appels concurrents écrasaient la référence, produisant des doublons.

## Fix

| Fichier | Changement |
|---|---|
| `JsonStringLocalizerBase.cs` | `_lazyLocalization` → `ConcurrentDictionary` ; `_cachedPluralizationRules` → `ConcurrentDictionary` |
| `JsonStringLocalizer.cs` | `_missingTranslations` → `ConcurrentDictionary` ; lookup via `_localizationCache[_currentCulture]` |
| `LocalizationModeBase.cs` | `AddOrUpdateLocalizedValue` devient `static`, prend `Dictionary` en paramètre |
| `LocalizationBasicModeGenerator.cs` | Utilise variable locale au lieu du champ partagé |
| `LocalizationI18NModeGenerator.cs` | Idem + propagation du dictionnaire dans `TraverseJson` |

## Test

3 nouveaux tests de charge concurrente dans `ConcurrentAccessTest.cs` (culture switching, pluralization, mixed). **57/57 tests verts** sur net8.0/net9.0/net10.0.

Fixes #18