### PR TITLE
fix: DefaultCulture setter use Equals instead of reference comparison (#23)

### DIFF
--- a/AspNetCore.Localizer.Json.Shared/JsonOptions/JsonLocalizationOptions.cs
+++ b/AspNetCore.Localizer.Json.Shared/JsonOptions/JsonLocalizationOptions.cs
@@ -41,7 +41,7 @@ namespace AspNetCore.Localizer.Json.JsonOptions
             get => defaultCulture;
             set
             {
-                if (value != defaultCulture)
+                if (value == null || !value.Equals(defaultCulture))
                 {
                     defaultCulture = value ?? CultureInfo.InvariantCulture;
                 }
@@ -58,7 +58,7 @@ namespace AspNetCore.Localizer.Json.JsonOptions
             get => defaultUICulture;
             set
             {
-                if (value != defaultUICulture)
+                if (value == null || !value.Equals(defaultUICulture))
                 {
                     defaultUICulture = value ?? CultureInfo.InvariantCulture;
                 }


### PR DESCRIPTION
## Problem

`DefaultCulture` and `DefaultUICulture` setters used `!=` (reference comparison) instead of value equality via `Equals()`. `CultureInfo` does not overload `!=`, so two distinct `CultureInfo` objects representing the same culture (e.g., two `new CultureInfo("en-US")`) would be treated as different, triggering unnecessary reassignment.

## Fix

- Changed `value != defaultCulture` → `value == null || !value.Equals(defaultCulture)`
- Same fix for `DefaultUICulture`
- Added null guard to preserve original behavior (`value ?? CultureInfo.InvariantCulture`)

Closes #23