### PR TITLE
fix: remove duplicate _disposed flag from derived class (#22)

### DIFF
--- a/AspNetCore.Localizer.Json.Shared/Localizer/JsonStringLocalizer.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/JsonStringLocalizer.cs
@@ -19,7 +19,6 @@ namespace AspNetCore.Localizer.Json.Localizer
     {
         private readonly string? _missingTranslationsFile = null;
         private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _missingTranslations = new();
-        private bool _disposed = false;
 
         public JsonStringLocalizer(IOptions<JsonLocalizationOptions> localizationOptions) : base(localizationOptions)
         {
@@ -40,13 +39,9 @@ namespace AspNetCore.Localizer.Json.Localizer
 
         protected override void Dispose(bool disposing)
         {
-            if (!_disposed)
+            if (disposing)
             {
-                if (disposing)
-                {
-                    _missingTranslations.Clear();
-                }
-                _disposed = true;
+                _missingTranslations.Clear();
             }
 
             base.Dispose(disposing);

--- a/test/AspNetCore.Localizer.Json.Test/Localizer/LocalizerLifecycleTest.cs
+++ b/test/AspNetCore.Localizer.Json.Test/Localizer/LocalizerLifecycleTest.cs
@@ -55,5 +55,22 @@ namespace AspNetCore.Localizer.Json.Test.Localizer
             // Should also find "Name1" in the same resource file
             Assert.AreEqual("My Name 1", withBaseName["Name1"].Value);
         }
+
+        [TestMethod]
+        public void Double_Dispose_Does_Not_Throw()
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+
+            var localizer = JsonStringLocalizerHelperFactory.Create(new JsonLocalizationOptions
+            {
+                DefaultCulture = new CultureInfo("en-US"),
+                SupportedCultureInfos = { new CultureInfo("en-US") },
+                ResourcesPath = "Resources",
+                UseEmbeddedResources = false
+            });
+
+            localizer.Dispose();
+            localizer.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Problem

`JsonStringLocalizer` (derived) has its own `_disposed` field duplicating the one in `JsonStringLocalizerBase`. Each dispose manages its own copy, creating risk of partial cleanup.

## Fix

- Removed `private bool _disposed` from `JsonStringLocalizer`
- Simplified `Dispose(bool)` to clean up derived resources and delegate to `base.Dispose(bool)`
- Base class `_disposed` is the single source of truth

## Test

- `Double_Dispose_Does_Not_Throw` — verifies calling `Dispose()` twice is safe

Closes #22