### PR TITLE
ci: publish to nuget.org via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v3
 
@@ -43,5 +47,11 @@ jobs:
         run: dotnet pack -o netCore -c Release /p:Version=${{ steps.version.outputs.nuget_version }}
         working-directory: AspNetCore.Localizer.Json
 
+      - name: NuGet login (Trusted Publishing)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push net core to nuget
-        run: dotnet nuget push AspNetCore.Localizer.Json/netCore/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push AspNetCore.Localizer.Json/netCore/*.nupkg -s https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}

--- a/AspNetCore.Localizer.Json.Shared/AspNetCore.Localizer.Json.Shared.projitems
+++ b/AspNetCore.Localizer.Json.Shared/AspNetCore.Localizer.Json.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>AspNetCore.Localizer.Json.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Commons\EmbeddedResourceCultureResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commons\IAssemblyHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commons\MultiAssemblyHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Format\JsonLocalizationFormat.cs" />

--- a/AspNetCore.Localizer.Json.Shared/Commons/EmbeddedResourceCultureResolver.cs
+++ b/AspNetCore.Localizer.Json.Shared/Commons/EmbeddedResourceCultureResolver.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AspNetCore.Localizer.Json.Commons
+{
+    /// <summary>
+    /// Resolves the culture code embedded in a manifest resource name.
+    /// Embedded resources use dotted names (e.g. "Namespace.i18n.localization.fr.json").
+    /// Two layouts are supported for the segments that follow the resource path:
+    ///   - suffix:  "{base}.{culture}"  (e.g. "url.fr")             -> culture is the last segment
+    ///   - folder:  "{culture}.{base}"  (e.g. "fr.localization")    -> culture is the first segment
+    /// A single segment after the resource path is always the file base name, never a culture,
+    /// which is what keeps a short base name such as "url" from being mistaken for a culture code.
+    /// </summary>
+    internal static class EmbeddedResourceCultureResolver
+    {
+        private static readonly Regex CultureNameRegex =
+            new("^[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8}){0,2}$", RegexOptions.Compiled);
+
+        public static string GetCulture(string resourceName, params string[] resourcePaths)
+        {
+            return GetCulture(resourceName, (IEnumerable<string>)resourcePaths);
+        }
+
+        public static string GetCulture(string resourceName, IEnumerable<string> resourcePaths)
+        {
+            var nameWithoutExt = Path.GetFileNameWithoutExtension(resourceName) ?? string.Empty;
+            var segments = nameWithoutExt.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+            var start = ResolveContentStart(segments, resourcePaths);
+            var contentLength = segments.Length - start;
+
+            // A single content segment is the file base name (neutral resource), not a culture.
+            if (contentLength <= 1)
+            {
+                return string.Empty;
+            }
+
+            var last = segments[segments.Length - 1];
+            if (IsCulture(last))
+            {
+                return last;
+            }
+
+            var first = segments[start];
+            if (IsCulture(first))
+            {
+                return first;
+            }
+
+            return string.Empty;
+        }
+
+        // The content (base name + optional culture) is everything after the resource-path segment.
+        // Any of the configured paths (primary ResourcesPath or an AdditionalResourcesPaths entry)
+        // may anchor this particular resource name, so we try them in order and use the first path
+        // that occurs. We anchor on the FIRST occurrence of that path so that a resource whose base
+        // name equals the folder name (e.g. "interpolation/interpolation.fr.json") does not swallow
+        // the trailing culture segment.
+        private static int ResolveContentStart(string[] segments, IEnumerable<string> resourcePaths)
+        {
+            if (resourcePaths == null)
+            {
+                return 0;
+            }
+
+            foreach (var path in resourcePaths)
+            {
+                if (string.IsNullOrEmpty(path))
+                {
+                    continue;
+                }
+
+                var idx = Array.FindIndex(segments,
+                    s => s.Equals(path, StringComparison.OrdinalIgnoreCase));
+                if (idx >= 0)
+                {
+                    return idx + 1;
+                }
+            }
+
+            return 0;
+        }
+
+        private static bool IsCulture(string segment)
+        {
+            return CultureNameRegex.IsMatch(segment)
+                   && !string.Equals(segment, CultureInfo.InvariantCulture.Name, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/AspNetCore.Localizer.Json.Shared/Localizer/JsonStringLocalizerBase.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/JsonStringLocalizerBase.cs
@@ -280,26 +280,13 @@ namespace AspNetCore.Localizer.Json.Localizer
                 return false;
             }
 
-            var nameWithoutExt = Path.GetFileNameWithoutExtension(resourceName) ?? string.Empty;
-            var segments = nameWithoutExt.Split('.', StringSplitOptions.RemoveEmptyEntries);
-
-            // Find the resource path segment and only look after it for culture codes
             var pathToLook = LocalizationOptions.Value.ResourcesPath ?? "Resources";
-            var resourcePathIndex = Array.FindIndex(segments,
-                s => s.Equals(pathToLook, StringComparison.OrdinalIgnoreCase));
-            var startIndex = resourcePathIndex >= 0 ? resourcePathIndex + 1 : 0;
-
-            for (var i = startIndex; i < segments.Length; i++)
-            {
-                if (CultureNameRegex.IsMatch(segments[i]) &&
-                    !string.Equals(segments[i], CultureInfo.InvariantCulture.Name, StringComparison.OrdinalIgnoreCase))
-                {
-                    return cultureCandidates.Contains(segments[i]);
-                }
-            }
+            var additionalPaths = LocalizationOptions.Value.AdditionalResourcesPaths ?? Array.Empty<string>();
+            var resourcePaths = new[] { pathToLook }.Concat(additionalPaths);
+            var culture = EmbeddedResourceCultureResolver.GetCulture(resourceName, resourcePaths);
 
             // No culture segment found: treat as neutral/default resource.
-            return true;
+            return string.IsNullOrEmpty(culture) || cultureCandidates.Contains(culture);
         }
         #endregion
 

--- a/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationI18NModeGenerator.cs
+++ b/AspNetCore.Localizer.Json.Shared/Localizer/Modes/LocalizationI18NModeGenerator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using AspNetCore.Localizer.Json.Commons;
 using AspNetCore.Localizer.Json.Format;
 using AspNetCore.Localizer.Json.JsonOptions;
 using AspNetCore.Localizer.Json.Localizer.Pooling;
@@ -33,7 +34,7 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
 
             foreach (string resourceName in resourceNames)
             {
-                string cultureName = GetCultureNameFromResource(resourceName, options.UseEmbeddedResources);
+                string cultureName = GetCultureNameFromResource(resourceName, options);
                 if (!IsRelevantCultureFile(cultureName, currentCulture, options))
                 {
                     continue;
@@ -93,25 +94,17 @@ namespace AspNetCore.Localizer.Json.Localizer.Modes
             return allowedCultures.Contains(cultureName);
         }
 
-        private static string GetCultureNameFromResource(string resourceName, bool useEmbeddedResources)
+        private static string GetCultureNameFromResource(string resourceName, JsonLocalizationOptions options)
         {
-            if (useEmbeddedResources)
+            if (options.UseEmbeddedResources)
             {
-                // Embedded resource names are dotted (e.g. "Namespace.Resources.fr.localization.json")
-                // The culture code is a segment before the file basename
-                var nameWithoutExt = Path.GetFileNameWithoutExtension(resourceName) ?? string.Empty;
-                var segments = nameWithoutExt.Split('.', StringSplitOptions.RemoveEmptyEntries);
-
-                // Walk segments in reverse to find the closest culture segment
-                for (int i = segments.Length - 1; i >= 0; i--)
-                {
-                    if (CultureNameRegex.IsMatch(segments[i]))
-                    {
-                        return segments[i];
-                    }
-                }
-
-                return string.Empty;
+                // Embedded resource names are dotted (e.g. "Namespace.Resources.fr.localization.json").
+                // Delegate to the shared resolver so a short file base name (e.g. "url") is not
+                // mistaken for a culture code (issue #44). Both the primary ResourcesPath and any
+                // AdditionalResourcesPaths may anchor the content segments.
+                var resourcePaths = new[] { options.ResourcesPath ?? "Resources" }
+                    .Concat(options.AdditionalResourcesPaths ?? Array.Empty<string>());
+                return EmbeddedResourceCultureResolver.GetCulture(resourceName, resourcePaths);
             }
 
             // For file-system paths, check the parent directory name (e.g. "Resources/fr/localization.json")

--- a/test/AspNetCore.Localizer.Json.Test/AspNetCore.Localizer.Json.Test.csproj
+++ b/test/AspNetCore.Localizer.Json.Test/AspNetCore.Localizer.Json.Test.csproj
@@ -38,6 +38,9 @@
     <EmbeddedResource Include="interpolation\**\*.json" WithCulture="false" />
     <EmbeddedResource Include="i18nLeak\**\*.json" WithCulture="false" />
     <EmbeddedResource Include="multiAssemblyA\**\*.json" WithCulture="false" />
+    <EmbeddedResource Include="i18nShortName\**\*.json" WithCulture="false" />
+    <EmbeddedResource Include="i18nExtra\**\*.json" WithCulture="false" />
+    <EmbeddedResource Include="i18nFolder\**\*.json" WithCulture="false" />
     <Content Include="physical\**\*.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/test/AspNetCore.Localizer.Json.Test/Localizer/ShortBaseNameEmbeddedResourceTest.cs
+++ b/test/AspNetCore.Localizer.Json.Test/Localizer/ShortBaseNameEmbeddedResourceTest.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+using AspNetCore.Localizer.Json.JsonOptions;
+using AspNetCore.Localizer.Json.Localizer;
+using AspNetCore.Localizer.Json.Test.Helpers;
+using Microsoft.Extensions.Localization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AspNetCore.Localizer.Json.Test.Localizer
+{
+    // Regression tests for issue #44: a 2-3 letter file basename (e.g. "url")
+    // was mistaken for a culture code by the embedded-resource culture filter,
+    // so url.json / url.fr.json were never discovered.
+    [TestClass]
+    public class ShortBaseNameEmbeddedResourceTest
+    {
+        private static JsonStringLocalizer CreateLocalizer(
+            CultureInfo uiCulture,
+            string resourcesPath = "i18nShortName",
+            string[] additionalPaths = null)
+        {
+            CultureInfo.CurrentUICulture = uiCulture;
+            return JsonStringLocalizerHelperFactory.Create(new JsonLocalizationOptions
+            {
+                DefaultCulture = new CultureInfo("en-US"),
+                SupportedCultureInfos = { new CultureInfo("en-US"), new CultureInfo("fr-FR") },
+                ResourcesPath = resourcesPath,
+                AdditionalResourcesPaths = additionalPaths ?? Array.Empty<string>(),
+                LocalizationMode = LocalizationMode.I18n,
+                UseEmbeddedResources = true,
+                AssemblyHelper = new AssemblyStub(Assembly.GetExecutingAssembly())
+            });
+        }
+
+        [TestMethod]
+        public void ShortBaseName_NeutralFile_IsDiscovered()
+        {
+            var localizer = CreateLocalizer(new CultureInfo("en-US"));
+
+            LocalizedString result = localizer["UrlKey"];
+
+            Assert.IsFalse(result.ResourceNotFound);
+            Assert.AreEqual("http://en", result.Value);
+        }
+
+        [TestMethod]
+        public void ShortBaseName_CultureSuffixFile_IsDiscovered()
+        {
+            var localizer = CreateLocalizer(new CultureInfo("fr-FR"));
+
+            LocalizedString result = localizer["UrlKey"];
+
+            Assert.IsFalse(result.ResourceNotFound);
+            Assert.AreEqual("http://fr", result.Value);
+        }
+
+        // A short base name carrying a culture suffix that does NOT match the current
+        // culture must still be filtered out (the base name is not a culture).
+        [TestMethod]
+        public void ShortBaseName_NonMatchingCultureSuffix_IsFiltered()
+        {
+            var localizer = CreateLocalizer(new CultureInfo("en-US"));
+
+            LocalizedString result = localizer["DeOnlyKey"];
+
+            Assert.IsTrue(result.ResourceNotFound);
+        }
+
+        // Issue #44 also reproduces when the short-base-name file lives under an
+        // AdditionalResourcesPaths entry rather than the primary ResourcesPath.
+        [TestMethod]
+        public void ShortBaseName_UnderAdditionalResourcesPath_IsDiscovered()
+        {
+            var localizer = CreateLocalizer(
+                new CultureInfo("en-US"),
+                resourcesPath: "i18nDoesNotExist",
+                additionalPaths: new[] { "i18nExtra" });
+
+            LocalizedString result = localizer["ApiKey"];
+
+            Assert.IsFalse(result.ResourceNotFound);
+            Assert.AreEqual("https://api/en", result.Value);
+        }
+
+        // Folder convention: culture segment precedes the base name
+        // (embedded "...i18nFolder.fr.localization.json"). Exercises the
+        // first-segment culture branch of the resolver.
+        [TestMethod]
+        public void FolderConventionCulture_IsDiscovered()
+        {
+            var localizer = CreateLocalizer(new CultureInfo("fr-FR"), resourcesPath: "i18nFolder");
+
+            LocalizedString result = localizer["FolderGreeting"];
+
+            Assert.IsFalse(result.ResourceNotFound);
+            Assert.AreEqual("Bonjour dossier", result.Value);
+        }
+
+        // Discriminates the folder-convention (first-segment) culture branch: a folder-culture
+        // file for a NON-current culture must be filtered out. If the first-segment culture were
+        // ignored, the file would fall through to "neutral" and load for every culture.
+        [TestMethod]
+        public void FolderConventionCulture_NonMatching_IsFiltered()
+        {
+            var localizer = CreateLocalizer(new CultureInfo("fr-FR"), resourcesPath: "i18nFolder");
+
+            LocalizedString result = localizer["GermanFolderKey"];
+
+            Assert.IsTrue(result.ResourceNotFound);
+        }
+    }
+}

--- a/test/AspNetCore.Localizer.Json.Test/i18nExtra/api.json
+++ b/test/AspNetCore.Localizer.Json.Test/i18nExtra/api.json
@@ -1,0 +1,3 @@
+{
+  "ApiKey": "https://api/en"
+}

--- a/test/AspNetCore.Localizer.Json.Test/i18nFolder/de/localization.json
+++ b/test/AspNetCore.Localizer.Json.Test/i18nFolder/de/localization.json
@@ -1,0 +1,3 @@
+{
+  "GermanFolderKey": "Hallo Ordner"
+}

--- a/test/AspNetCore.Localizer.Json.Test/i18nFolder/fr/localization.json
+++ b/test/AspNetCore.Localizer.Json.Test/i18nFolder/fr/localization.json
@@ -1,0 +1,3 @@
+{
+  "FolderGreeting": "Bonjour dossier"
+}

--- a/test/AspNetCore.Localizer.Json.Test/i18nShortName/url.de.json
+++ b/test/AspNetCore.Localizer.Json.Test/i18nShortName/url.de.json
@@ -1,0 +1,3 @@
+{
+  "DeOnlyKey": "http://de"
+}

--- a/test/AspNetCore.Localizer.Json.Test/i18nShortName/url.fr.json
+++ b/test/AspNetCore.Localizer.Json.Test/i18nShortName/url.fr.json
@@ -1,0 +1,3 @@
+{
+  "UrlKey": "http://fr"
+}

--- a/test/AspNetCore.Localizer.Json.Test/i18nShortName/url.json
+++ b/test/AspNetCore.Localizer.Json.Test/i18nShortName/url.json
@@ -1,0 +1,3 @@
+{
+  "UrlKey": "http://en"
+}


### PR DESCRIPTION
## What

Migrates the NuGet publish job to [nuget.org Trusted Publishing (OIDC)](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing), replacing the long-lived `NUGET_API_KEY` secret with a short-lived key minted at publish time.

Changes to `.github/workflows/publish.yml` (job `build`) only:

- Added `permissions: contents: read` / `id-token: write` — required so the runner can request the OIDC token.
- Added a `NuGet/login@v1` step (`id: nuget-login`) placed **immediately before** the push. The temporary key is valid for 1 hour only, so the login happens as late as possible in the job.
- The push now uses `--api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}` instead of the repository secret. (Note: the previous step used the `-k` short form; it is now the explicit `--api-key`, same flag.)

Nothing else in the workflow was touched.

## ⚠️ Manual prerequisites — required BEFORE merging

This workflow only triggers on `push: tags: - "**"`. **There is no PR/`workflow_dispatch` trigger, so CI cannot validate this change on this PR.** The very first execution of the new code path will be the next real release. If the policy and the secret are not in place beforehand, that release will fail.

### 1. Create the Trusted Publishing policy on nuget.org

Under your nuget.org account → **Trusted Publishing** → *Add policy*:

| Field | Value |
|---|---|
| Repository Owner | `AskmethatFR` |
| Repository | `AspNetCore.Localizer.Json` |
| Workflow File | `publish.yml` |
| Environment | *(leave empty — the job declares no `environment:`)* |

### 2. Package glob patterns

List the package IDs explicitly, one per line:

```
AspNetCore.Localizer.Json
```

This is the only `<PackageId>` produced by the packed project (`AspNetCore.Localizer.Json/AspNetCore.Localizer.Json.csproj`).

**Do not use `*`** — a wildcard would let this workflow publish *any* package owned by the account.

### 3. Create the `NUGET_USER` repository secret

`gh secret list` confirms it does **not** exist yet — only `NUGET_API_KEY` is present.

The value is the **nuget.org profile/username** that owns the Trusted Publishing policy — **not the email address**.

```
gh secret set NUGET_USER
```

### 4. Retire the old secret — after the first successful OIDC publish

Keep `NUGET_API_KEY` in place until an OIDC publish has succeeded end to end, so a rollback is possible. Once the first release publishes through Trusted Publishing, delete it:

```
gh secret delete NUGET_API_KEY
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
